### PR TITLE
fix notification redirect issue for reply/comment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
         applicationId "com.hapramp"
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 59
+        versionCode 62
         versionName "0.0.16"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/app/src/main/java/com/hapramp/notification/NotificationHandler.java
+++ b/app/src/main/java/com/hapramp/notification/NotificationHandler.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.app.TaskStackBuilder;
+import android.util.Log;
 
 import com.google.firebase.messaging.RemoteMessage;
 import com.hapramp.R;
@@ -144,7 +145,7 @@ public class NotificationHandler {
     String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
     String title = "Reblog";
     String content = reblogger + " shared your post";
-    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author,"", permlink);
+    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, "", permlink);
     addNotificationToTray(HapRampMain.getContext(), pendingIntent, title, content);
   }
 
@@ -152,14 +153,13 @@ public class NotificationHandler {
    * @param notificationId
    * @param commentor      user who created comment
    * @param permlink       permlink of new comment/reply.
+   * Clicking on notification, opens the comment/reply created by commentor.
    */
   private static void showCommentDirectedNotification(String notificationId, String commentor, String parentPermlink, String permlink) {
     Context context = HapRampMain.getContext();
-    //you are the author of the post
-    String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
     String title = "Comment";
     String content = commentor + " commented on your post";
-    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, parentPermlink, permlink);
+    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, commentor, parentPermlink, permlink);
     addNotificationToTray(HapRampMain.getContext(), pendingIntent, title, content);
   }
 
@@ -196,14 +196,13 @@ public class NotificationHandler {
    * @param notificationId
    * @param mentioner      user who mentioned you in his/her post.
    * @param permlink       permlink of post in which you were mentioned.
+   * Clicking on notification, opens post in which user is mentioned
    */
   private static void showMentionDirectedNotification(String notificationId, String mentioner, String parentPermlink, String permlink) {
     Context context = HapRampMain.getContext();
-    //you are the author of the post
-    String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
     String title = "Mention";
     String content = mentioner + " mentioned you in a post";
-    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, parentPermlink, permlink);
+    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, mentioner, parentPermlink, permlink);
     addNotificationToTray(HapRampMain.getContext(), pendingIntent, title, content);
   }
 

--- a/app/src/main/java/com/hapramp/ui/activity/DetailedActivity.java
+++ b/app/src/main/java/com/hapramp/ui/activity/DetailedActivity.java
@@ -205,7 +205,6 @@ public class DetailedActivity extends AppCompatActivity implements
       String permlink = bundle.getString(Constants.EXTRAA_KEY_POST_PERMLINK);
       final String parentPermlink = bundle.getString(Constants.EXTRAA_KEY_PARENT_PERMLINK, "");
       String notifId = getIntent().getExtras().getString(Constants.EXTRAA_KEY_NOTIFICATION_ID, null);
-      Log.d("DetailedPost",parentPermlink+" ---");
       if (parentPermlink.length() > 0) {
         //show goto parent button
         if (gotoParentBtn != null) {
@@ -215,7 +214,7 @@ public class DetailedActivity extends AppCompatActivity implements
             public void onClick(View view) {
               String me = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
               if (me.length() > 0) {
-                openDetailsPage(me,parentPermlink);
+                openDetailsPage(me, parentPermlink);
               }
             }
           });

--- a/app/src/main/java/com/hapramp/ui/adapters/NotificationAdapter.java
+++ b/app/src/main/java/com/hapramp/ui/adapters/NotificationAdapter.java
@@ -175,7 +175,7 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
       String userImageUrl = String.format(itemView.getContext()
         .getString(R.string.steem_user_profile_pic_format_large), followNotificationModel.getFollower());
       ImageHandler.loadCircularImage(itemView.getContext(), userImage, userImageUrl);
-      text.setText(String.format("%s Started following you.", followNotificationModel.getFollower()));
+      text.setText(String.format("%s started following you.", followNotificationModel.getFollower()));
       itemView.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View view) {
@@ -204,7 +204,7 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
       String userImageUrl = String.format(itemView.getContext()
         .getString(R.string.steem_user_profile_pic_format_large), mentionNotificationModel.getAuthor());
       ImageHandler.loadCircularImage(itemView.getContext(), userImage, userImageUrl);
-      text.setText(String.format("%s Mentioned you in a post", mentionNotificationModel.getAuthor()));
+      text.setText(String.format("%s mentioned you in a post", mentionNotificationModel.getAuthor()));
       timestamp.setText(MomentsUtils.getFormattedTime(mentionNotificationModel.getTimestamp()));
       itemView.setOnClickListener(new View.OnClickListener() {
         @Override
@@ -236,7 +236,7 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
       String userImageUrl = String.format(itemView.getContext()
         .getString(R.string.steem_user_profile_pic_format_large), reblogNotificationModel.getAccount());
       ImageHandler.loadCircularImage(itemView.getContext(), userImage, userImageUrl);
-      text.setText(String.format("%s Reblogged your post", reblogNotificationModel.getAccount()));
+      text.setText(String.format("%s reblogged your post", reblogNotificationModel.getAccount()));
       timestamp.setText(MomentsUtils.getFormattedTime(reblogNotificationModel.getTimestamp()));
       itemView.setOnClickListener(new View.OnClickListener() {
         @Override
@@ -270,7 +270,7 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
       String userImageUrl = String.format(itemView.getContext()
         .getString(R.string.steem_user_profile_pic_format_large), replyNotificationModel.getAuthor());
       ImageHandler.loadCircularImage(itemView.getContext(), userImage, userImageUrl);
-      text.setText(String.format("%s Replied on your post.", replyNotificationModel.getAuthor()));
+      text.setText(String.format("%s replied on your post.", replyNotificationModel.getAuthor()));
       timestamp.setText(MomentsUtils.getFormattedTime(replyNotificationModel.getTimestamp()));
       itemView.setOnClickListener(new View.OnClickListener() {
         @Override
@@ -303,7 +303,7 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         .getString(R.string.steem_user_profile_pic_format_large), transferNotificationModel.getFrom());
       ImageHandler.loadCircularImage(itemView.getContext(), userImage, userImageUrl);
       timestamp.setText(MomentsUtils.getFormattedTime(transferNotificationModel.getTimestamp()));
-      text.setText(String.format("%s Sent %s to you.", transferNotificationModel.getFrom(),
+      text.setText(String.format("%s sent %s to you.", transferNotificationModel.getFrom(),
         transferNotificationModel.getAmount()));
       itemView.setOnClickListener(new View.OnClickListener() {
         @Override
@@ -333,7 +333,7 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         .getString(R.string.steem_user_profile_pic_format_large), voteNotificationModel.getVoter());
       ImageHandler.loadCircularImage(itemView.getContext(), userImage, userImageUrl);
       timestamp.setText(MomentsUtils.getFormattedTime(voteNotificationModel.getTimestamp()));
-      text.setText(String.format("%s Voted your post", voteNotificationModel.getVoter()));
+      text.setText(String.format("%s voted your post", voteNotificationModel.getVoter()));
       itemView.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View view) {


### PR DESCRIPTION
**Issue:**
On clicking notification of reply/comment, the user was taken to the details page with incorrect post due to wrong `author` of the post.


Applying this PR fixes the issue.